### PR TITLE
Add a flake.nix for the overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1619323048,
+        "narHash": "sha256-wiLspuRrtX4JPO2Xpd0ySsaN+g5i5BVfslCfcIcHSrU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1fe6ed37fd9beb92afe90671c0c2a662a03463dd",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,15 @@
+{
+  description = "The nixek overlay";
+
+  outputs = { self, nixpkgs }: rec {
+    overlay = final: prev: {
+      pulumi = final.callPackage ./pkgs/tools/admin/pulumi {};
+
+      pulumi-sdk = final.callPackage ./pkgs/tools/admin/pulumi/sdk.nix {};
+
+      kube2pulumi = final.callPackage ./pkgs/tools/admin/kube2pulumi {};
+    };
+
+    packages.x86_64-linux = (import nixpkgs { system = "x86_64-linux"; overlays = [ self.overlay ]; });
+  };
+}


### PR DESCRIPTION
Flakes are the future.

For now, only support x86_64 for simplicity, even though I'm sure we'll
want other archs eventually.