### PR TITLE
pulumi: add version build flags all around

### DIFF
--- a/pkgs/tools/admin/crd2pulumi/default.nix
+++ b/pkgs/tools/admin/crd2pulumi/default.nix
@@ -12,6 +12,8 @@ buildGoModule rec {
   };
   vendorSha256 = "sha256-baTGg8kydp9FxxsGiP7SCQGhgODs+4fH7dkS74TaJXY=";
 
+  buildFlagsArray = [ "-ldflags=-X github.com/pulumi/crd2pulumi/gen.Version=v${version}" ];
+
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/tools/admin/kube2pulumi/default.nix
+++ b/pkgs/tools/admin/kube2pulumi/default.nix
@@ -12,6 +12,9 @@ buildGoModule rec {
   };
   vendorSha256 = "sha256-0ujtuidGHrVe9Abam4mVz/ZvwBisihOzFsSYDEJzivg=";
 
+  # https://github.com/pulumi/kube2pulumi/blob/9809268a81c139373572713549b5560e847eb6e9/.goreleaser.yml
+  buildFlagsArray = [ "-ldflags=-X github.com/pulumi/kube2pulumi/pkg/version.Version=v${version}" ];
+
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -12,6 +12,8 @@ buildGoModule rec {
   };
   vendorSha256 = "sha256-GeDcorNNhRykkAV+Fo8EIhjar1h0X8zxmh0iCNKTYFw=";
 
+  buildFlagsArray = [ "-ldflags=-X github.com/pulumi/pulumi/pkg/v3/version.Version=v${version}" ];
+
   doCheck = false;
 
   modRoot = "./pkg";

--- a/pkgs/tools/admin/pulumi/sdk.nix
+++ b/pkgs/tools/admin/pulumi/sdk.nix
@@ -12,8 +12,9 @@ buildGoModule rec {
   };
   vendorSha256 = "sha256-WhkEiZu0EcjeYcH0vpMweeF1Gn84WMt7WZXvgMfKrbA=";
 
-  doCheck = false;
 
+  doCheck = false;
+  buildFlagsArray = [ "-ldflags=-X github.com/pulumi/pulumi/pkg/v3/version.Version=v${version}" ];
   modRoot = "./sdk";
   subPackages = [ "nodejs/cmd/pulumi-language-nodejs" ];
 


### PR DESCRIPTION
This was necessary for crd2pulumi to work at all. Go back and clean up the others too.